### PR TITLE
Fix import test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ validate :
 
 # Run tests on analysis code
 test :
-	nosetests --no-byte-compile test/*
+	nosetests --no-byte-compile
 
 # Automate running the analysis code
 analysis :

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,5 +1,9 @@
 # Tests for the trivial example code in code/example.py
 from __future__ import absolute_import
+import sys
+import os
+# Temporarily add the repo path to the PYTHONPATH so that code can be imported
+sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
 from code.example import add
 
 from nose.tools import assert_raises


### PR DESCRIPTION
NOTE: this only works with `nosetests` called from the repository root directory (which means `make test` in the repository root directory will now work. For some reason this **doesn't** work with `pytest` but does with `nosetests`. This is likely due to some `env` freeze.